### PR TITLE
Build the frame-aware browser shell and instrumentation layer

### DIFF
--- a/modules/browser-host/expo-module.config.json
+++ b/modules/browser-host/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple", "web"],
+  "apple": {
+    "modules": ["BrowserHostModule"]
+  }
+}

--- a/modules/browser-host/index.ts
+++ b/modules/browser-host/index.ts
@@ -1,0 +1,2 @@
+export { default } from './src/BrowserHostView';
+export * from './src/BrowserHost.types';

--- a/modules/browser-host/ios/BrowserHost.podspec
+++ b/modules/browser-host/ios/BrowserHost.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name           = 'BrowserHost'
+  s.version        = '1.0.0'
+  s.summary        = 'Muninn native browser host view'
+  s.description    = 'A local Expo module that wraps WKWebView for trusted browser control operations.'
+  s.author         = ''
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/browser-host/ios/BrowserHostModule.swift
+++ b/modules/browser-host/ios/BrowserHostModule.swift
@@ -1,0 +1,66 @@
+import ExpoModulesCore
+
+public class BrowserHostModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("BrowserHost")
+
+    View(BrowserHostView.self) {
+      Prop("sourceUrl") { (view: BrowserHostView, sourceUrl: String?) in
+        view.sourceUrl = sourceUrl
+      }
+
+      Prop("sourceHtml") { (view: BrowserHostView, sourceHtml: String?) in
+        view.sourceHtml = sourceHtml
+      }
+
+      Prop("sourceBaseUrl") { (view: BrowserHostView, sourceBaseUrl: String?) in
+        view.sourceBaseUrl = sourceBaseUrl
+      }
+
+      Prop("bootstrapScript") { (view: BrowserHostView, bootstrapScript: String?) in
+        view.bootstrapScript = bootstrapScript
+      }
+
+      Prop("afterContentScript") { (view: BrowserHostView, afterContentScript: String?) in
+        view.afterContentScript = afterContentScript
+      }
+
+      OnViewDidUpdateProps { view in
+        view.syncInjectedScriptsIfNeeded()
+        view.applySourceIfNeeded()
+      }
+
+      Events(
+        "onLoadStart",
+        "onLoadProgress",
+        "onNavigationStateChange",
+        "onNavigationError",
+        "onTelemetryMessage"
+      )
+
+      AsyncFunction("evaluateJavaScript") { (view: BrowserHostView, source: String, promise: Promise) in
+        view.evaluateJavaScript(source, promise: promise)
+      }
+
+      AsyncFunction("goBack") { (view: BrowserHostView) -> NSNull in
+        view.goBack()
+        return NSNull()
+      }
+
+      AsyncFunction("goForward") { (view: BrowserHostView) -> NSNull in
+        view.goForward()
+        return NSNull()
+      }
+
+      AsyncFunction("reload") { (view: BrowserHostView) -> NSNull in
+        view.reload()
+        return NSNull()
+      }
+
+      AsyncFunction("stopLoading") { (view: BrowserHostView) -> NSNull in
+        view.stopLoading()
+        return NSNull()
+      }
+    }
+  }
+}

--- a/modules/browser-host/ios/BrowserHostView.swift
+++ b/modules/browser-host/ios/BrowserHostView.swift
@@ -1,0 +1,327 @@
+import ExpoModulesCore
+import WebKit
+
+class BrowserHostView: ExpoView, WKNavigationDelegate {
+  static let telemetryHandlerName = "muninnBrowserHostTelemetry"
+
+  private lazy var telemetryMessageHandler = BrowserHostScriptMessageHandler(owner: self)
+  private let onLoadProgress = EventDispatcher()
+  private let onLoadStart = EventDispatcher()
+  private let onNavigationError = EventDispatcher()
+  private let onNavigationStateChange = EventDispatcher()
+  private let onTelemetryMessage = EventDispatcher()
+  private let webView: WKWebView
+
+  private var lastAppliedScriptSignature: String?
+  private var lastAppliedSourceSignature: String?
+  private var progressObservation: NSKeyValueObservation?
+
+  var afterContentScript: String?
+  var bootstrapScript: String?
+  var sourceBaseUrl: String?
+  var sourceHtml: String?
+  var sourceUrl: String?
+
+  required init(appContext: AppContext? = nil) {
+    let configuration = WKWebViewConfiguration()
+    configuration.userContentController = WKUserContentController()
+
+    webView = WKWebView(frame: .zero, configuration: configuration)
+
+    super.init(appContext: appContext)
+
+    clipsToBounds = true
+    webView.allowsBackForwardNavigationGestures = true
+    webView.navigationDelegate = self
+
+    addSubview(webView)
+
+    resetInjectedScripts()
+
+    progressObservation = webView.observe(\.estimatedProgress, options: [.new]) { [weak self] webView, _ in
+      self?.onLoadProgress([
+        "progress": webView.estimatedProgress
+      ])
+      self?.emitNavigationState()
+    }
+  }
+
+  deinit {
+    progressObservation?.invalidate()
+    webView.configuration.userContentController.removeScriptMessageHandler(forName: Self.telemetryHandlerName)
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    webView.frame = bounds
+  }
+
+  func syncInjectedScriptsIfNeeded() {
+    let signature = [bootstrapScript ?? "", afterContentScript ?? ""].joined(separator: "\u{1F}")
+
+    guard signature != lastAppliedScriptSignature else {
+      return
+    }
+
+    lastAppliedScriptSignature = signature
+    resetInjectedScripts()
+  }
+
+  func applySourceIfNeeded() {
+    let signature = [sourceUrl ?? "", sourceHtml ?? "", sourceBaseUrl ?? ""].joined(separator: "\u{1F}")
+
+    guard signature != lastAppliedSourceSignature else {
+      return
+    }
+
+    lastAppliedSourceSignature = signature
+
+    if let sourceHtml, !sourceHtml.isEmpty {
+      let baseUrl = sourceBaseUrl.flatMap(URL.init(string:))
+      webView.loadHTMLString(sourceHtml, baseURL: baseUrl)
+      return
+    }
+
+    guard let sourceUrl, !sourceUrl.isEmpty else {
+      return
+    }
+
+    guard let url = URL(string: sourceUrl) else {
+      onNavigationError([
+        "description": "Invalid browser URL.",
+        "type": "navigation_error",
+        "url": sourceUrl
+      ])
+      return
+    }
+
+    webView.load(URLRequest(url: url))
+  }
+
+  func evaluateJavaScript(_ source: String, promise: Promise) {
+    let evaluateBlock = { [weak self] in
+      guard let self else {
+        promise.resolve([
+          "code": "execution_error",
+          "details": NSNull(),
+          "message": "Browser host view is no longer mounted.",
+          "ok": false
+        ])
+        return
+      }
+
+      self.webView.evaluateJavaScript(source) { value, error in
+        if let error = error as NSError? {
+          promise.resolve([
+            "code": "execution_error",
+            "details": [
+              "code": error.code,
+              "domain": error.domain,
+              "message": error.localizedDescription
+            ],
+            "message": error.localizedDescription,
+            "ok": false
+          ])
+          return
+        }
+
+        promise.resolve([
+          "ok": true,
+          "value": BrowserHostView.serializeJavaScriptValue(value)
+        ])
+      }
+    }
+
+    if Thread.isMainThread {
+      evaluateBlock()
+    } else {
+      DispatchQueue.main.async(execute: evaluateBlock)
+    }
+  }
+
+  func goBack() {
+    runOnMain {
+      self.webView.goBack()
+    }
+  }
+
+  func goForward() {
+    runOnMain {
+      self.webView.goForward()
+    }
+  }
+
+  func reload() {
+    runOnMain {
+      self.webView.reload()
+    }
+  }
+
+  func stopLoading() {
+    runOnMain {
+      self.webView.stopLoading()
+    }
+  }
+
+  func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+    onLoadStart([
+      "url": currentUrl()
+    ])
+    emitNavigationState()
+  }
+
+  func webView(_ webView: WKWebView, didCommit _: WKNavigation!) {
+    emitNavigationState()
+  }
+
+  func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+    emitNavigationState()
+  }
+
+  func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError error: Error) {
+    emitNavigationError(error, fallbackUrl: currentUrl())
+    emitNavigationState()
+  }
+
+  func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError error: Error) {
+    emitNavigationError(error, fallbackUrl: currentUrl())
+    emitNavigationState()
+  }
+
+  func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
+    let data = BrowserHostView.stringifyScriptMessageBody(message.body)
+    onTelemetryMessage([
+      "data": data
+    ])
+  }
+
+  private func runOnMain(_ block: @escaping () -> Void) {
+    if Thread.isMainThread {
+      block()
+    } else {
+      DispatchQueue.main.async(execute: block)
+    }
+  }
+
+  private func resetInjectedScripts() {
+    let controller = webView.configuration.userContentController
+    controller.removeAllUserScripts()
+    controller.removeScriptMessageHandler(forName: Self.telemetryHandlerName)
+    controller.add(telemetryMessageHandler, name: Self.telemetryHandlerName)
+
+    if let bootstrapScript, !bootstrapScript.isEmpty {
+      controller.addUserScript(
+        WKUserScript(
+          source: bootstrapScript,
+          injectionTime: .atDocumentStart,
+          forMainFrameOnly: false
+        )
+      )
+    }
+
+    if let afterContentScript, !afterContentScript.isEmpty {
+      controller.addUserScript(
+        WKUserScript(
+          source: afterContentScript,
+          injectionTime: .atDocumentEnd,
+          forMainFrameOnly: false
+        )
+      )
+    }
+  }
+
+  private func emitNavigationState() {
+    onNavigationStateChange([
+      "canGoBack": webView.canGoBack,
+      "canGoForward": webView.canGoForward,
+      "isLoading": webView.isLoading,
+      "title": webView.title ?? "",
+      "url": currentUrl()
+    ])
+  }
+
+  private func emitNavigationError(_ error: Error, fallbackUrl: String) {
+    let resolvedError = error as NSError
+
+    onNavigationError([
+      "code": resolvedError.code,
+      "description": resolvedError.localizedDescription,
+      "type": "navigation_error",
+      "url": fallbackUrl
+    ])
+  }
+
+  private func currentUrl() -> String {
+    if let absoluteString = webView.url?.absoluteString {
+      return absoluteString
+    }
+    if let sourceUrl {
+      return sourceUrl
+    }
+    if let sourceBaseUrl {
+      return sourceBaseUrl
+    }
+    return ""
+  }
+
+  private static func serializeJavaScriptValue(_ value: Any?) -> Any {
+    guard let value else {
+      return [
+        "type": "undefined"
+      ]
+    }
+
+    if value is NSNull || value is NSString || value is NSNumber {
+      return value
+    }
+
+    if let array = value as? [Any] {
+      return array.map { serializeJavaScriptValue($0) }
+    }
+
+    if let dictionary = value as? [String: Any] {
+      return dictionary.mapValues { serializeJavaScriptValue($0) }
+    }
+
+    if let dictionary = value as? NSDictionary {
+      var serializedDictionary: [String: Any] = [:]
+
+      for (key, dictionaryValue) in dictionary {
+        serializedDictionary[String(describing: key)] = serializeJavaScriptValue(dictionaryValue)
+      }
+
+      return serializedDictionary
+    }
+
+    return [
+      "type": "string",
+      "value": String(describing: value)
+    ]
+  }
+
+  private static func stringifyScriptMessageBody(_ body: Any) -> String {
+    if let string = body as? String {
+      return string
+    }
+
+    if JSONSerialization.isValidJSONObject(body),
+       let data = try? JSONSerialization.data(withJSONObject: body),
+       let jsonString = String(data: data, encoding: .utf8) {
+      return jsonString
+    }
+
+    return String(describing: body)
+  }
+}
+
+private final class BrowserHostScriptMessageHandler: NSObject, WKScriptMessageHandler {
+  weak var owner: BrowserHostView?
+
+  init(owner: BrowserHostView) {
+    self.owner = owner
+  }
+
+  func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    owner?.userContentController(userContentController, didReceive: message)
+  }
+}

--- a/modules/browser-host/src/BrowserHost.types.ts
+++ b/modules/browser-host/src/BrowserHost.types.ts
@@ -1,0 +1,70 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+
+export type BrowserHostNavigationStatePayload = {
+  canGoBack: boolean;
+  canGoForward: boolean;
+  isLoading: boolean;
+  title: string;
+  url: string;
+};
+
+export type BrowserHostNavigationErrorPayload = {
+  code?: number;
+  description: string;
+  statusCode?: number;
+  type: 'navigation_error' | 'http_error';
+  url: string;
+};
+
+export type BrowserHostProgressPayload = {
+  progress: number;
+};
+
+export type BrowserHostLoadStartPayload = {
+  url: string;
+};
+
+export type BrowserHostTelemetryPayload = {
+  data: string;
+};
+
+export type BrowserHostEvaluationOutcome =
+  | {
+      ok: true;
+      value: unknown;
+    }
+  | {
+      code: 'execution_error' | 'serialization_error';
+      details?: unknown;
+      message: string;
+      ok: false;
+    };
+
+export type BrowserHostViewProps = {
+  afterContentScript?: string | null;
+  bootstrapScript?: string | null;
+  onLoadProgress?: (event: { nativeEvent: BrowserHostProgressPayload }) => void;
+  onLoadStart?: (event: { nativeEvent: BrowserHostLoadStartPayload }) => void;
+  onNavigationError?: (event: {
+    nativeEvent: BrowserHostNavigationErrorPayload;
+  }) => void;
+  onNavigationStateChange?: (event: {
+    nativeEvent: BrowserHostNavigationStatePayload;
+  }) => void;
+  onTelemetryMessage?: (event: { nativeEvent: BrowserHostTelemetryPayload }) => void;
+  sourceBaseUrl?: string | null;
+  sourceHtml?: string | null;
+  sourceUrl?: string | null;
+  style?: StyleProp<ViewStyle>;
+};
+
+export type BrowserHostViewHandle = {
+  evaluateJavaScript: (
+    source: string
+  ) => Promise<BrowserHostEvaluationOutcome>;
+  goBack: () => Promise<null>;
+  goForward: () => Promise<null>;
+  nativeTag: number | null;
+  reload: () => Promise<null>;
+  stopLoading: () => Promise<null>;
+};

--- a/modules/browser-host/src/BrowserHostView.tsx
+++ b/modules/browser-host/src/BrowserHostView.tsx
@@ -1,0 +1,17 @@
+import { requireNativeView } from 'expo';
+import * as React from 'react';
+
+import type { BrowserHostViewHandle, BrowserHostViewProps } from './BrowserHost.types';
+
+const NativeView =
+  requireNativeView('BrowserHost') as React.ComponentType<
+    BrowserHostViewProps & React.RefAttributes<BrowserHostViewHandle>
+  >;
+
+const BrowserHostView = React.forwardRef<BrowserHostViewHandle, BrowserHostViewProps>(
+  function BrowserHostView(props, ref) {
+    return <NativeView {...props} ref={ref as never} />;
+  }
+);
+
+export default BrowserHostView;

--- a/modules/browser-host/src/BrowserHostView.web.tsx
+++ b/modules/browser-host/src/BrowserHostView.web.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { View } from 'react-native';
+
+import type { BrowserHostViewHandle, BrowserHostViewProps } from './BrowserHost.types';
+
+const BrowserHostView = React.forwardRef<BrowserHostViewHandle, BrowserHostViewProps>(
+  function BrowserHostView(props, ref) {
+    React.useImperativeHandle(ref, () => ({
+      evaluateJavaScript: async () => ({
+        ok: false,
+        code: 'execution_error',
+        message: 'BrowserHost is only implemented natively on iOS.',
+      }),
+      goBack: async () => null,
+      goForward: async () => null,
+      nativeTag: null,
+      reload: async () => null,
+      stopLoading: async () => null,
+    }));
+
+    return <View style={props.style} />;
+  }
+);
+
+export default BrowserHostView;

--- a/src/features/browser/bridge/bootstrap.ts
+++ b/src/features/browser/bridge/bootstrap.ts
@@ -3,15 +3,23 @@ import {
   BROWSER_BRIDGE_VERSION,
 } from './protocol';
 
-const BRIDGE_GLOBAL_KEY = '__MUNINN_BRIDGE__';
+const TELEMETRY_HANDLER_NAME = 'muninnBrowserHostTelemetry';
 
 export function buildBridgeBootstrapScript() {
   return `
 (function () {
   const CHANNEL = ${JSON.stringify(BROWSER_BRIDGE_CHANNEL)};
   const VERSION = ${JSON.stringify(BROWSER_BRIDGE_VERSION)};
-  const BRIDGE_KEY = ${JSON.stringify(BRIDGE_GLOBAL_KEY)};
+  const HANDLER_NAME = ${JSON.stringify(TELEMETRY_HANDLER_NAME)};
   const FRAME_KEY = '__MUNINN_FRAME_ID__';
+
+  function isTopFrame() {
+    try {
+      return window.top === window.self;
+    } catch (error) {
+      return false;
+    }
+  }
 
   function getFrameId() {
     if (!window[FRAME_KEY]) {
@@ -23,89 +31,8 @@ export function buildBridgeBootstrapScript() {
     return window[FRAME_KEY];
   }
 
-  function isTopFrame() {
-    try {
-      return window.top === window.self;
-    } catch (error) {
-      return false;
-    }
-  }
-
   function safeString(value) {
     return typeof value === 'string' ? value : null;
-  }
-
-  function serializeValue(value) {
-    if (value === undefined) {
-      return { type: 'undefined' };
-    }
-
-    if (value === null) {
-      return null;
-    }
-
-    if (
-      typeof value === 'string' ||
-      typeof value === 'number' ||
-      typeof value === 'boolean'
-    ) {
-      return value;
-    }
-
-    if (value instanceof Error) {
-      return {
-        type: 'error',
-        name: value.name,
-        message: value.message,
-        stack: safeString(value.stack),
-      };
-    }
-
-    if (typeof value === 'function') {
-      return {
-        type: 'function',
-        name: safeString(value.name),
-      };
-    }
-
-    try {
-      return JSON.parse(JSON.stringify(value));
-    } catch (error) {
-      return {
-        type: 'string',
-        value: String(value),
-      };
-    }
-  }
-
-  function serializeError(error, source, fallbackMessage) {
-    const resolvedMessage =
-      error && typeof error === 'object' && typeof error.message === 'string'
-        ? error.message
-        : fallbackMessage;
-
-    return {
-      source: source,
-      name:
-        error && typeof error === 'object' && typeof error.name === 'string'
-          ? error.name
-          : 'Error',
-      message: resolvedMessage || 'Unknown bridge error.',
-      stack:
-        error && typeof error === 'object' && typeof error.stack === 'string'
-          ? error.stack
-          : null,
-    };
-  }
-
-  function getFrame() {
-    return {
-      frameId: getFrameId(),
-      url: String(window.location.href),
-      title: typeof document.title === 'string' && document.title.length > 0 ? document.title : null,
-      isTopFrame: isTopFrame(),
-      readyState: typeof document.readyState === 'string' ? document.readyState : null,
-    };
   }
 
   function normalizeDetail(detail) {
@@ -123,15 +50,47 @@ export function buildBridgeBootstrapScript() {
     }
   }
 
+  function serializeError(error, source, fallbackMessage) {
+    const resolvedMessage =
+      error && typeof error === 'object' && typeof error.message === 'string'
+        ? error.message
+        : fallbackMessage;
+
+    return {
+      source: source,
+      name:
+        error && typeof error === 'object' && typeof error.name === 'string'
+          ? error.name
+          : 'Error',
+      message: resolvedMessage || 'Unknown telemetry error.',
+      stack:
+        error && typeof error === 'object' && typeof error.stack === 'string'
+          ? error.stack
+          : null,
+    };
+  }
+
+  function getFrame() {
+    return {
+      frameId: getFrameId(),
+      url: String(window.location.href),
+      title: typeof document.title === 'string' && document.title.length > 0 ? document.title : null,
+      isTopFrame: isTopFrame(),
+      readyState: typeof document.readyState === 'string' ? document.readyState : null,
+    };
+  }
+
   function post(kind, payload) {
     if (
-      !window.ReactNativeWebView ||
-      typeof window.ReactNativeWebView.postMessage !== 'function'
+      !window.webkit ||
+      !window.webkit.messageHandlers ||
+      !window.webkit.messageHandlers[HANDLER_NAME] ||
+      typeof window.webkit.messageHandlers[HANDLER_NAME].postMessage !== 'function'
     ) {
       return;
     }
 
-    window.ReactNativeWebView.postMessage(
+    window.webkit.messageHandlers[HANDLER_NAME].postMessage(
       JSON.stringify({
         channel: CHANNEL,
         kind: kind,
@@ -148,53 +107,6 @@ export function buildBridgeBootstrapScript() {
       detail: normalizeDetail(detail),
     });
   }
-
-  const existingBridge = window[BRIDGE_KEY];
-
-  if (existingBridge && existingBridge.version === VERSION) {
-    emitPageEvent('bridge_reused', {
-      url: window.location.href,
-    });
-
-    post('bridge_ready', {
-      bridgeVersion: VERSION,
-      readyState: document.readyState,
-      reused: true,
-      userAgent: navigator.userAgent,
-    });
-
-    return true;
-  }
-
-  const bridge = {
-    version: VERSION,
-    emitPageEvent: emitPageEvent,
-    runEval: function (requestId, source) {
-      Promise.resolve()
-        .then(function () {
-          return (0, eval)(source);
-        })
-        .then(function (value) {
-          post('eval_result', {
-            requestId: requestId,
-            value: serializeValue(value),
-          });
-        })
-        .catch(function (error) {
-          post('eval_error', {
-            requestId: requestId,
-            code: 'execution_error',
-            message:
-              error && typeof error === 'object' && typeof error.message === 'string'
-                ? error.message
-                : 'JavaScript evaluation failed.',
-            details: serializeError(error, 'bridge', 'JavaScript evaluation failed.'),
-          });
-        });
-    },
-  };
-
-  window[BRIDGE_KEY] = bridge;
 
   window.addEventListener('error', function (event) {
     post(
@@ -265,56 +177,46 @@ export function buildBridgeBootstrapScript() {
 export function buildBridgeAfterContentScript() {
   return `
 (function () {
-  const bridge = window[${JSON.stringify(BRIDGE_GLOBAL_KEY)}];
+  const HANDLER_NAME = ${JSON.stringify(TELEMETRY_HANDLER_NAME)};
 
-  if (bridge && typeof bridge.emitPageEvent === 'function') {
-    bridge.emitPageEvent('post_content_injected', {
-      title: document.title || null,
-      url: window.location.href,
-    });
-  }
-
-  return true;
-})();
-`;
-}
-
-export function buildBridgeEvaluationScript(requestId: string, source: string) {
-  return `
-(function () {
-  const bridge = window[${JSON.stringify(BRIDGE_GLOBAL_KEY)}];
-
-  if (!bridge || typeof bridge.runEval !== 'function') {
-    if (
-      window.ReactNativeWebView &&
-      typeof window.ReactNativeWebView.postMessage === 'function'
-    ) {
-      window.ReactNativeWebView.postMessage(
-        JSON.stringify({
-          channel: ${JSON.stringify(BROWSER_BRIDGE_CHANNEL)},
-          kind: 'eval_error',
-          timestamp: new Date().toISOString(),
-          frame: {
-            frameId: 'bridge-unavailable',
-            url: String(window.location.href),
-            title: document.title || null,
-            isTopFrame: true,
-            readyState: document.readyState || null,
-          },
-          payload: {
-            requestId: ${JSON.stringify(requestId)},
-            code: 'bridge_unavailable',
-            message: 'Muninn bridge is not ready on the page.',
-            details: null,
-          },
-        })
-      );
-    }
-
+  if (
+    !window.webkit ||
+    !window.webkit.messageHandlers ||
+    !window.webkit.messageHandlers[HANDLER_NAME] ||
+    typeof window.webkit.messageHandlers[HANDLER_NAME].postMessage !== 'function'
+  ) {
     return true;
   }
 
-  bridge.runEval(${JSON.stringify(requestId)}, ${JSON.stringify(source)});
+  function isTopFrame() {
+    try {
+      return window.top === window.self;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  const message = {
+    channel: ${JSON.stringify(BROWSER_BRIDGE_CHANNEL)},
+    kind: 'page_event',
+    timestamp: new Date().toISOString(),
+    frame: {
+      frameId: 'post-content-' + Date.now().toString(36),
+      url: String(window.location.href),
+      title: document.title || null,
+      isTopFrame: isTopFrame(),
+      readyState: document.readyState || null,
+    },
+    payload: {
+      event: 'post_content_injected',
+      detail: {
+        title: document.title || null,
+        url: window.location.href,
+      },
+    },
+  };
+
+  window.webkit.messageHandlers[HANDLER_NAME].postMessage(JSON.stringify(message));
   return true;
 })();
 `;

--- a/src/features/browser/bridge/protocol.ts
+++ b/src/features/browser/bridge/protocol.ts
@@ -74,7 +74,7 @@ function isEvaluationErrorType(
   value: unknown
 ): value is BrowserEvaluationErrorType {
   return (
-    value === 'bridge_unavailable' ||
+    value === 'native_unavailable' ||
     value === 'timeout' ||
     value === 'execution_error' ||
     value === 'serialization_error' ||

--- a/src/features/browser/components/BrowserChrome.tsx
+++ b/src/features/browser/components/BrowserChrome.tsx
@@ -12,7 +12,7 @@ import { BRIDGE_FIXTURE_URL } from '../fixtures/bridge-fixture';
 import { normalizeBrowserUrl } from '../utils/url';
 
 type BrowserChromeProps = {
-  bridgeReady: boolean;
+  telemetryReady: boolean;
   canGoBack: boolean;
   canGoForward: boolean;
   currentUrl: string;
@@ -28,7 +28,7 @@ type BrowserChromeProps = {
 };
 
 export function BrowserChrome({
-  bridgeReady,
+  telemetryReady,
   canGoBack,
   canGoForward,
   currentUrl,
@@ -78,9 +78,14 @@ export function BrowserChrome({
           </Text>
         </View>
 
-        <View style={[styles.bridgePill, bridgeReady ? styles.bridgeReady : null]}>
+        <View
+          style={[
+            styles.bridgePill,
+            telemetryReady ? styles.bridgeReady : null,
+          ]}
+        >
           <Text style={styles.bridgePillText}>
-            {bridgeReady ? 'Bridge ready' : 'Bridge pending'}
+            {telemetryReady ? 'Telemetry active' : 'Telemetry pending'}
           </Text>
         </View>
       </View>

--- a/src/features/browser/components/BrowserWebView.tsx
+++ b/src/features/browser/components/BrowserWebView.tsx
@@ -3,24 +3,19 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
-import WebView from 'react-native-webview';
-import type {
-  WebViewErrorEvent,
-  WebViewHttpErrorEvent,
-  WebViewMessageEvent,
-  WebViewNavigation,
-  WebViewNavigationEvent,
-  WebViewNativeEvent,
-  WebViewProgressEvent,
-} from 'react-native-webview/lib/WebViewTypes';
+import { StyleSheet, View } from 'react-native';
 
+import {
+  BrowserHostView,
+  type BrowserHostEvaluationOutcome,
+  type BrowserHostViewHandle as NativeBrowserHostViewHandle,
+} from '../../../native/browser-host';
 import {
   buildBridgeAfterContentScript,
   buildBridgeBootstrapScript,
-  buildBridgeEvaluationScript,
 } from '../bridge/bootstrap';
 import { parseBrowserBridgeMessage } from '../bridge/protocol';
 import type {
@@ -36,21 +31,20 @@ import { resolveBrowserSource } from '../utils/url';
 
 type BrowserWebViewProps = {
   requestedUrl: string;
-  onBridgeMessage?: (message: BrowserBridgeMessage) => void;
-  onBridgeProtocolError?: (error: BrowserBridgeParseError) => void;
   onLoadStart?: () => void;
   onNavigationError?: (error: BrowserNavigationError) => void;
   onNavigationStateChange?: (
     navigationState: BrowserNavigationStateSnapshot
   ) => void;
   onProgressChange?: (progress: number) => void;
+  onTelemetryMessage?: (message: BrowserBridgeMessage) => void;
+  onTelemetryProtocolError?: (error: BrowserBridgeParseError) => void;
 };
 
 export type BrowserWebViewHandle = {
   evaluateJavaScript: <T = unknown>(
     source: string,
     options?: {
-      bridgeReadyTimeoutMs?: number;
       timeoutMs?: number;
     }
   ) => Promise<BrowserEvaluationResult<T>>;
@@ -66,11 +60,6 @@ type PendingEvaluation = {
   timeoutId: ReturnType<typeof setTimeout>;
 };
 
-type BridgeReadyWaiter = {
-  resolve: (ready: boolean) => void;
-  timeoutId: ReturnType<typeof setTimeout>;
-};
-
 const BRIDGE_BOOTSTRAP_SCRIPT = buildBridgeBootstrapScript();
 const BRIDGE_AFTER_CONTENT_SCRIPT = buildBridgeAfterContentScript();
 
@@ -78,46 +67,24 @@ export const BrowserWebView = forwardRef<BrowserWebViewHandle, BrowserWebViewPro
   function BrowserWebView(
     {
       requestedUrl,
-      onBridgeMessage,
-      onBridgeProtocolError,
       onLoadStart,
       onNavigationError,
       onNavigationStateChange,
       onProgressChange,
+      onTelemetryMessage,
+      onTelemetryProtocolError,
     },
     ref
   ) {
-    const webViewRef = useRef<WebView>(null);
-    const bridgeReadyRef = useRef(false);
-    const mainFrameRef = useRef<BrowserFrameMetadata | null>(null);
-    const pendingEvaluationsRef = useRef<Map<string, PendingEvaluation>>(
-      new Map()
-    );
-    const bridgeWaitersRef = useRef<BridgeReadyWaiter[]>([]);
+    const hostRef = useRef<NativeBrowserHostViewHandle>(null);
+    const mainTelemetryFrameRef = useRef<BrowserFrameMetadata | null>(null);
+    const pendingEvaluationsRef = useRef<Map<string, PendingEvaluation>>(new Map());
     const requestIdRef = useRef(0);
 
-    const notifyNavigationState = useCallback(
-      (navigationState: WebViewNativeEvent) => {
-        onNavigationStateChange?.({
-          canGoBack: navigationState.canGoBack,
-          canGoForward: navigationState.canGoForward,
-          isLoading: navigationState.loading,
-          title: navigationState.title,
-          url: navigationState.url,
-        });
-      },
-      [onNavigationStateChange]
+    const source = useMemo(
+      () => resolveBrowserSource(requestedUrl),
+      [requestedUrl]
     );
-
-    const resolveBridgeWaiters = useCallback((ready: boolean) => {
-      const waiters = bridgeWaitersRef.current;
-      bridgeWaitersRef.current = [];
-
-      waiters.forEach((waiter) => {
-        clearTimeout(waiter.timeoutId);
-        waiter.resolve(ready);
-      });
-    }, []);
 
     const resolvePendingEvaluation = useCallback(
       (requestId: string, result: BrowserEvaluationResult) => {
@@ -159,99 +126,25 @@ export const BrowserWebView = forwardRef<BrowserWebViewHandle, BrowserWebViewPro
       []
     );
 
-    const waitForBridgeReady = useCallback(
-      (timeoutMs: number) => {
-        if (bridgeReadyRef.current) {
-          return Promise.resolve(true);
-        }
+    const handleLoadStart = useCallback(() => {
+      mainTelemetryFrameRef.current = null;
+      failPendingEvaluations(
+        'navigation_changed',
+        'Page navigation interrupted pending evaluation.'
+      );
+      onLoadStart?.();
+    }, [failPendingEvaluations, onLoadStart]);
 
-        return new Promise<boolean>((resolve) => {
-          const timeoutId = setTimeout(() => {
-            bridgeWaitersRef.current = bridgeWaitersRef.current.filter(
-              (waiter) => waiter.timeoutId !== timeoutId
-            );
-            resolve(false);
-          }, timeoutMs);
-
-          bridgeWaitersRef.current.push({
-            resolve,
-            timeoutId,
-          });
-        });
-      },
-      []
-    );
-
-    const handleLoadStart = useCallback(
-      (event: WebViewErrorEvent | WebViewNavigationEvent) => {
-        bridgeReadyRef.current = false;
-        mainFrameRef.current = null;
-        resolveBridgeWaiters(false);
-        failPendingEvaluations(
-          'navigation_changed',
-          'Page navigation interrupted pending evaluation.'
-        );
-        onLoadStart?.();
-        notifyNavigationState(event.nativeEvent);
-      },
-      [failPendingEvaluations, notifyNavigationState, onLoadStart, resolveBridgeWaiters]
-    );
-
-    const handleLoadProgress = useCallback(
-      (event: WebViewProgressEvent) => {
-        onProgressChange?.(event.nativeEvent.progress);
-      },
-      [onProgressChange]
-    );
-
-    const handleLoadEnd = useCallback(
-      (event: WebViewErrorEvent | WebViewNavigationEvent) => {
-        notifyNavigationState(event.nativeEvent);
-      },
-      [notifyNavigationState]
-    );
-
-    const handleNavigationStateChange = useCallback(
-      (navigationState: WebViewNavigation) => {
-        notifyNavigationState(navigationState);
-      },
-      [notifyNavigationState]
-    );
-
-    const handleNavigationError = useCallback(
-      (event: WebViewErrorEvent) => {
-        onNavigationError?.({
-          type: 'navigation_error',
-          code: event.nativeEvent.code,
-          description: event.nativeEvent.description,
-          url: event.nativeEvent.url,
-        });
-      },
-      [onNavigationError]
-    );
-
-    const handleHttpError = useCallback(
-      (event: WebViewHttpErrorEvent) => {
-        onNavigationError?.({
-          type: 'http_error',
-          description: event.nativeEvent.description,
-          statusCode: event.nativeEvent.statusCode,
-          url: event.nativeEvent.url,
-        });
-      },
-      [onNavigationError]
-    );
-
-    const handleBridgeMessage = useCallback(
-      (event: WebViewMessageEvent) => {
-        const parsedMessage = parseBrowserBridgeMessage(event.nativeEvent.data);
+    const handleTelemetryMessage = useCallback(
+      (rawMessage: string) => {
+        const parsedMessage = parseBrowserBridgeMessage(rawMessage);
 
         if (!parsedMessage) {
           return;
         }
 
         if ('type' in parsedMessage) {
-          onBridgeProtocolError?.(parsedMessage);
+          onTelemetryProtocolError?.(parsedMessage);
           return;
         }
 
@@ -259,44 +152,12 @@ export const BrowserWebView = forwardRef<BrowserWebViewHandle, BrowserWebViewPro
           parsedMessage.kind === 'bridge_ready' &&
           parsedMessage.frame.isTopFrame
         ) {
-          bridgeReadyRef.current = true;
-          mainFrameRef.current = parsedMessage.frame;
-          resolveBridgeWaiters(true);
+          mainTelemetryFrameRef.current = parsedMessage.frame;
         }
 
-        if (parsedMessage.kind === 'eval_result') {
-          const pending = pendingEvaluationsRef.current.get(parsedMessage.payload.requestId);
-
-          if (pending) {
-            resolvePendingEvaluation(parsedMessage.payload.requestId, {
-              ok: true,
-              requestId: parsedMessage.payload.requestId,
-              value: parsedMessage.payload.value,
-              frame: parsedMessage.frame,
-              elapsedMs: Date.now() - pending.startedAt,
-            });
-          }
-        }
-
-        if (parsedMessage.kind === 'eval_error') {
-          const pending = pendingEvaluationsRef.current.get(parsedMessage.payload.requestId);
-
-          if (pending) {
-            resolvePendingEvaluation(parsedMessage.payload.requestId, {
-              ok: false,
-              requestId: parsedMessage.payload.requestId,
-              type: parsedMessage.payload.code,
-              message: parsedMessage.payload.message,
-              details: parsedMessage.payload.details,
-              frame: parsedMessage.frame,
-              elapsedMs: Date.now() - pending.startedAt,
-            });
-          }
-        }
-
-        onBridgeMessage?.(parsedMessage);
+        onTelemetryMessage?.(parsedMessage);
       },
-      [onBridgeMessage, onBridgeProtocolError, resolveBridgeWaiters, resolvePendingEvaluation]
+      [onTelemetryMessage, onTelemetryProtocolError]
     );
 
     useImperativeHandle(
@@ -305,34 +166,20 @@ export const BrowserWebView = forwardRef<BrowserWebViewHandle, BrowserWebViewPro
         evaluateJavaScript: async <T = unknown>(
           source: string,
           options?: {
-            bridgeReadyTimeoutMs?: number;
             timeoutMs?: number;
           }
         ) => {
           const requestId = createRequestId(++requestIdRef.current);
-          const bridgeReadyTimeoutMs = options?.bridgeReadyTimeoutMs ?? 2500;
           const timeoutMs = options?.timeoutMs ?? 4000;
           const startedAt = Date.now();
 
-          if (!webViewRef.current) {
+          if (!hostRef.current) {
             return {
               ok: false,
               requestId,
-              type: 'bridge_unavailable',
-              message: 'The browser host is not mounted.',
+              type: 'native_unavailable',
+              message: 'The native browser host is not mounted.',
               elapsedMs: 0,
-            };
-          }
-
-          const bridgeReady = await waitForBridgeReady(bridgeReadyTimeoutMs);
-
-          if (!bridgeReady) {
-            return {
-              ok: false,
-              requestId,
-              type: 'bridge_unavailable',
-              message: 'Timed out waiting for the browser bridge to become ready.',
-              elapsedMs: Date.now() - startedAt,
             };
           }
 
@@ -344,7 +191,7 @@ export const BrowserWebView = forwardRef<BrowserWebViewHandle, BrowserWebViewPro
                 requestId,
                 type: 'timeout',
                 message: `Timed out waiting for JavaScript evaluation after ${timeoutMs}ms.`,
-                frame: mainFrameRef.current ?? undefined,
+                frame: mainTelemetryFrameRef.current ?? undefined,
                 elapsedMs: Date.now() - startedAt,
               });
             }, timeoutMs);
@@ -355,51 +202,91 @@ export const BrowserWebView = forwardRef<BrowserWebViewHandle, BrowserWebViewPro
               timeoutId,
             });
 
-            webViewRef.current?.injectJavaScript(
-              buildBridgeEvaluationScript(requestId, source)
-            );
+            hostRef.current
+              ?.evaluateJavaScript(source)
+              .then((result: BrowserHostEvaluationOutcome) => {
+                if (result.ok) {
+                  resolvePendingEvaluation(requestId, {
+                    ok: true,
+                    requestId,
+                    value: result.value as T,
+                    elapsedMs: Date.now() - startedAt,
+                  });
+                  return;
+                }
+
+                resolvePendingEvaluation(requestId, {
+                  ok: false,
+                  requestId,
+                  type: result.code,
+                  message: result.message,
+                  details: result.details,
+                  elapsedMs: Date.now() - startedAt,
+                });
+              })
+              .catch((error: unknown) => {
+                resolvePendingEvaluation(requestId, {
+                  ok: false,
+                  requestId,
+                  type: 'execution_error',
+                  message:
+                    error instanceof Error
+                      ? error.message
+                      : 'Native JavaScript evaluation failed.',
+                  details: error,
+                  elapsedMs: Date.now() - startedAt,
+                });
+              });
           });
         },
-        goBack: () => webViewRef.current?.goBack(),
-        goForward: () => webViewRef.current?.goForward(),
-        reload: () => webViewRef.current?.reload(),
-        stopLoading: () => webViewRef.current?.stopLoading(),
+        goBack: () => {
+          hostRef.current?.goBack().catch(() => undefined);
+        },
+        goForward: () => {
+          hostRef.current?.goForward().catch(() => undefined);
+        },
+        reload: () => {
+          hostRef.current?.reload().catch(() => undefined);
+        },
+        stopLoading: () => {
+          hostRef.current?.stopLoading().catch(() => undefined);
+        },
       }),
-      [waitForBridgeReady]
+      [resolvePendingEvaluation]
     );
 
     useEffect(() => {
       return () => {
-        resolveBridgeWaiters(false);
         failPendingEvaluations(
           'navigation_changed',
           'Browser host unmounted before evaluation completed.'
         );
       };
-    }, [failPendingEvaluations, resolveBridgeWaiters]);
+    }, [failPendingEvaluations]);
 
     return (
       <View style={styles.container}>
-        <WebView
-          allowsBackForwardNavigationGestures
-          injectedJavaScript={BRIDGE_AFTER_CONTENT_SCRIPT}
-          injectedJavaScriptBeforeContentLoaded={BRIDGE_BOOTSTRAP_SCRIPT}
-          injectedJavaScriptBeforeContentLoadedForMainFrameOnly={
-            Platform.OS !== 'ios'
-          }
-          injectedJavaScriptForMainFrameOnly={Platform.OS !== 'ios'}
-          javaScriptEnabled
-          originWhitelist={['http://*', 'https://*', 'about:*']}
-          onError={handleNavigationError}
-          onHttpError={handleHttpError}
-          onLoadEnd={handleLoadEnd}
-          onLoadProgress={handleLoadProgress}
+        <BrowserHostView
+          afterContentScript={BRIDGE_AFTER_CONTENT_SCRIPT}
+          bootstrapScript={BRIDGE_BOOTSTRAP_SCRIPT}
+          onLoadProgress={(event) => {
+            onProgressChange?.(event.nativeEvent.progress);
+          }}
           onLoadStart={handleLoadStart}
-          onMessage={handleBridgeMessage}
-          onNavigationStateChange={handleNavigationStateChange}
-          ref={webViewRef}
-          source={resolveBrowserSource(requestedUrl)}
-          style={styles.webView}
+          onNavigationError={(event) => {
+            onNavigationError?.(event.nativeEvent);
+          }}
+          onNavigationStateChange={(event) => {
+            onNavigationStateChange?.(event.nativeEvent);
+          }}
+          onTelemetryMessage={(event) => {
+            handleTelemetryMessage(event.nativeEvent.data);
+          }}
+          ref={hostRef}
+          sourceBaseUrl={'baseUrl' in source ? source.baseUrl ?? null : null}
+          sourceHtml={'html' in source ? source.html : null}
+          sourceUrl={'uri' in source ? source.uri : null}
+          style={styles.host}
         />
       </View>
     );
@@ -415,7 +302,7 @@ const styles = StyleSheet.create({
     flex: 1,
     overflow: 'hidden',
   },
-  webView: {
+  host: {
     flex: 1,
   },
 });

--- a/src/features/browser/fixtures/bridge-fixture.ts
+++ b/src/features/browser/fixtures/bridge-fixture.ts
@@ -87,6 +87,7 @@ const IFRAME_HTML = `
 `;
 
 export const BRIDGE_FIXTURE_URL = 'fixture://bridge';
+export const BRIDGE_FIXTURE_BASE_URL = 'https://fixture.muninn.local/';
 
 export function buildBridgeFixtureHtml() {
   return `

--- a/src/features/browser/screens/BrowserScreen.tsx
+++ b/src/features/browser/screens/BrowserScreen.tsx
@@ -36,16 +36,18 @@ export function BrowserScreen() {
   const isLoading = useBrowserStore((state) => state.isLoading);
   const canGoBack = useBrowserStore((state) => state.canGoBack);
   const canGoForward = useBrowserStore((state) => state.canGoForward);
-  const bridgeReady = useBrowserStore((state) => state.bridgeReady);
+  const telemetryReady = useBrowserStore((state) => state.telemetryReady);
   const framesById = useBrowserStore((state) => state.frames);
   const lastNavigationError = useBrowserStore(
     (state) => state.lastNavigationError
   );
   const lastScriptError = useBrowserStore((state) => state.lastScriptError);
-  const lastBridgeProtocolError = useBrowserStore(
-    (state) => state.lastBridgeProtocolError
+  const lastTelemetryProtocolError = useBrowserStore(
+    (state) => state.lastTelemetryProtocolError
   );
-  const lastBridgeMessage = useBrowserStore((state) => state.lastBridgeMessage);
+  const lastTelemetryMessage = useBrowserStore(
+    (state) => state.lastTelemetryMessage
+  );
   const setRequestedUrl = useBrowserStore((state) => state.setRequestedUrl);
   const applyNavigationState = useBrowserStore(
     (state) => state.applyNavigationState
@@ -54,12 +56,14 @@ export function BrowserScreen() {
   const setNavigationError = useBrowserStore(
     (state) => state.setNavigationError
   );
-  const clearBridgeState = useBrowserStore((state) => state.clearBridgeState);
-  const registerBridgeMessage = useBrowserStore(
-    (state) => state.registerBridgeMessage
+  const clearTelemetryState = useBrowserStore(
+    (state) => state.clearTelemetryState
   );
-  const setBridgeProtocolError = useBrowserStore(
-    (state) => state.setBridgeProtocolError
+  const registerTelemetryMessage = useBrowserStore(
+    (state) => state.registerTelemetryMessage
+  );
+  const setTelemetryProtocolError = useBrowserStore(
+    (state) => state.setTelemetryProtocolError
   );
 
   const goal = useAgentSessionStore((state) => state.goal);
@@ -128,7 +132,7 @@ export function BrowserScreen() {
         result ?? {
           ok: false,
           requestId: 'browser-host-missing',
-          type: 'bridge_unavailable',
+          type: 'native_unavailable',
           message: 'Browser host ref was unavailable.',
           elapsedMs: 0,
         }
@@ -141,16 +145,16 @@ export function BrowserScreen() {
   const handleBrowserLoadStart = () => {
     setProgress(0);
     setNavigationError(null);
-    setBridgeProtocolError(null);
-    clearBridgeState();
+    setTelemetryProtocolError(null);
+    clearTelemetryState();
   };
 
-  const handleBrowserMessage = (message: BrowserBridgeMessage) => {
-    registerBridgeMessage(message);
+  const handleTelemetryMessage = (message: BrowserBridgeMessage) => {
+    registerTelemetryMessage(message);
   };
 
-  const handleBrowserProtocolError = (error: BrowserBridgeParseError) => {
-    setBridgeProtocolError(error);
+  const handleTelemetryProtocolError = (error: BrowserBridgeParseError) => {
+    setTelemetryProtocolError(error);
   };
 
   return (
@@ -160,7 +164,7 @@ export function BrowserScreen() {
     >
       <SafeAreaView edges={['top']} style={styles.container}>
         <BrowserChrome
-          bridgeReady={bridgeReady}
+          telemetryReady={telemetryReady}
           canGoBack={canGoBack}
           canGoForward={canGoForward}
           currentUrl={currentUrl}
@@ -223,8 +227,8 @@ export function BrowserScreen() {
               value={loopState}
             />
             <StatusCard
-              label="Bridge"
-              value={bridgeReady ? 'Ready' : 'Pending'}
+              label="Telemetry"
+              value={telemetryReady ? 'Untrusted events seen' : 'Pending'}
             />
             <StatusCard
               label="Current URL"
@@ -241,16 +245,16 @@ export function BrowserScreen() {
             value={formatValue(lastEvaluationResult)}
           />
           <StatusCard
-            label="Last bridge message"
-            value={formatValue(lastBridgeMessage)}
+            label="Last telemetry message"
+            value={formatValue(lastTelemetryMessage)}
           />
           <StatusCard
             label="Last script error"
             value={formatValue(lastScriptError)}
           />
           <StatusCard
-            label="Last bridge protocol error"
-            value={formatValue(lastBridgeProtocolError)}
+            label="Last telemetry protocol error"
+            value={formatValue(lastTelemetryProtocolError)}
           />
           <StatusCard
             label="Last navigation error"
@@ -268,12 +272,12 @@ export function BrowserScreen() {
 
         <View style={styles.webviewFrame}>
           <BrowserWebView
-            onBridgeMessage={handleBrowserMessage}
-            onBridgeProtocolError={handleBrowserProtocolError}
             onLoadStart={handleBrowserLoadStart}
             onNavigationError={setNavigationError}
             onNavigationStateChange={applyNavigationState}
             onProgressChange={setProgress}
+            onTelemetryMessage={handleTelemetryMessage}
+            onTelemetryProtocolError={handleTelemetryProtocolError}
             ref={browserRef}
             requestedUrl={requestedUrl}
           />

--- a/src/features/browser/types.ts
+++ b/src/features/browser/types.ts
@@ -38,7 +38,7 @@ export type BrowserBridgeReadyPayload = {
 };
 
 export type BrowserEvaluationErrorType =
-  | 'bridge_unavailable'
+  | 'native_unavailable'
   | 'timeout'
   | 'execution_error'
   | 'serialization_error'
@@ -88,6 +88,8 @@ export type BrowserEvaluationErrorMessage = BrowserBridgeEnvelopeBase & {
   payload: BrowserEvaluationErrorPayload;
 };
 
+// Untrusted telemetry emitted from page-world JavaScript. Never use this as an
+// authenticity boundary for agent control flow.
 export type BrowserBridgeMessage =
   | BrowserBridgeReadyMessage
   | BrowserPageEventMessage
@@ -121,7 +123,7 @@ export type BrowserEvaluationSuccess<T = unknown> = {
   ok: true;
   requestId: string;
   value: T;
-  frame: BrowserFrameMetadata;
+  frame?: BrowserFrameMetadata;
   elapsedMs: number;
 };
 

--- a/src/features/browser/utils/url.ts
+++ b/src/features/browser/utils/url.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_BROWSER_URL } from '../../../config/runtime';
 import {
+  BRIDGE_FIXTURE_BASE_URL,
   BRIDGE_FIXTURE_URL,
   buildBridgeFixtureHtml,
 } from '../fixtures/bridge-fixture';
@@ -39,7 +40,7 @@ export function resolveBrowserSource(url: string): BrowserSource {
   if (isBridgeFixtureUrl(url)) {
     return {
       html: buildBridgeFixtureHtml(),
-      baseUrl: 'https://fixture.muninn.local/',
+      baseUrl: BRIDGE_FIXTURE_BASE_URL,
     };
   }
 

--- a/src/native/browser-host.ts
+++ b/src/native/browser-host.ts
@@ -1,0 +1,11 @@
+export { default as BrowserHostView } from '../../modules/browser-host';
+export type {
+  BrowserHostEvaluationOutcome,
+  BrowserHostLoadStartPayload,
+  BrowserHostNavigationErrorPayload,
+  BrowserHostNavigationStatePayload,
+  BrowserHostProgressPayload,
+  BrowserHostTelemetryPayload,
+  BrowserHostViewHandle,
+  BrowserHostViewProps,
+} from '../../modules/browser-host';

--- a/src/state/browser-store.ts
+++ b/src/state/browser-store.ts
@@ -1,6 +1,10 @@
 import { create } from 'zustand';
 
 import { DEFAULT_BROWSER_URL } from '../config/runtime';
+import {
+  BRIDGE_FIXTURE_BASE_URL,
+  BRIDGE_FIXTURE_URL,
+} from '../features/browser/fixtures/bridge-fixture';
 import type {
   BrowserBridgeMessage,
   BrowserBridgeParseError,
@@ -18,20 +22,20 @@ type BrowserState = {
   isLoading: boolean;
   canGoBack: boolean;
   canGoForward: boolean;
-  bridgeReady: boolean;
+  telemetryReady: boolean;
   mainFrameId: string | null;
   frames: Record<string, BrowserFrameMetadata>;
   lastNavigationError: BrowserNavigationError | null;
   lastScriptError: BrowserScriptErrorMessage | null;
-  lastBridgeProtocolError: BrowserBridgeParseError | null;
-  lastBridgeMessage: BrowserBridgeMessage | null;
+  lastTelemetryProtocolError: BrowserBridgeParseError | null;
+  lastTelemetryMessage: BrowserBridgeMessage | null;
   setRequestedUrl: (url: string) => void;
   applyNavigationState: (navigationState: BrowserNavigationStateSnapshot) => void;
   setProgress: (progress: number) => void;
   setNavigationError: (error: BrowserNavigationError | null) => void;
-  clearBridgeState: () => void;
-  registerBridgeMessage: (message: BrowserBridgeMessage) => void;
-  setBridgeProtocolError: (error: BrowserBridgeParseError | null) => void;
+  clearTelemetryState: () => void;
+  registerTelemetryMessage: (message: BrowserBridgeMessage) => void;
+  setTelemetryProtocolError: (error: BrowserBridgeParseError | null) => void;
 };
 
 export const useBrowserStore = create<BrowserState>((set) => ({
@@ -42,27 +46,32 @@ export const useBrowserStore = create<BrowserState>((set) => ({
   isLoading: true,
   canGoBack: false,
   canGoForward: false,
-  bridgeReady: false,
+  telemetryReady: false,
   mainFrameId: null,
   frames: {},
   lastNavigationError: null,
   lastScriptError: null,
-  lastBridgeProtocolError: null,
-  lastBridgeMessage: null,
+  lastTelemetryProtocolError: null,
+  lastTelemetryMessage: null,
   setRequestedUrl: (requestedUrl) =>
     set({
       requestedUrl,
       lastNavigationError: null,
     }),
   applyNavigationState: (navigationState) =>
-    set({
+    set((state) => ({
+      requestedUrl:
+        state.requestedUrl === BRIDGE_FIXTURE_URL &&
+        navigationState.url.startsWith(BRIDGE_FIXTURE_BASE_URL)
+          ? BRIDGE_FIXTURE_URL
+          : navigationState.url,
       currentUrl: navigationState.url,
       title: navigationState.title,
       isLoading: navigationState.isLoading,
       canGoBack: navigationState.canGoBack,
       canGoForward: navigationState.canGoForward,
       lastNavigationError: null,
-    }),
+    })),
   setProgress: (progress) =>
     set({
       progress,
@@ -72,25 +81,26 @@ export const useBrowserStore = create<BrowserState>((set) => ({
     set({
       lastNavigationError,
     }),
-  clearBridgeState: () =>
+  clearTelemetryState: () =>
     set({
-      bridgeReady: false,
+      telemetryReady: false,
       mainFrameId: null,
       frames: {},
-      lastBridgeMessage: null,
+      lastTelemetryMessage: null,
       lastScriptError: null,
-      lastBridgeProtocolError: null,
+      lastTelemetryProtocolError: null,
     }),
-  registerBridgeMessage: (message) =>
+  registerTelemetryMessage: (message) =>
     set((state) => {
       const frames = {
         ...state.frames,
         [message.frame.frameId]: message.frame,
       };
 
-      const bridgeReady = message.kind === 'bridge_ready' && message.frame.isTopFrame
+      const telemetryReady =
+        message.kind === 'bridge_ready' && message.frame.isTopFrame
         ? true
-        : state.bridgeReady;
+        : state.telemetryReady;
       const mainFrameId =
         message.frame.isTopFrame && message.kind === 'bridge_ready'
           ? message.frame.frameId
@@ -98,15 +108,15 @@ export const useBrowserStore = create<BrowserState>((set) => ({
 
       return {
         frames,
-        bridgeReady,
+        telemetryReady,
         mainFrameId,
         lastScriptError:
           message.kind === 'script_error' ? message : state.lastScriptError,
-        lastBridgeMessage: message,
+        lastTelemetryMessage: message,
       };
     }),
-  setBridgeProtocolError: (lastBridgeProtocolError) =>
+  setTelemetryProtocolError: (lastTelemetryProtocolError) =>
     set({
-      lastBridgeProtocolError,
+      lastTelemetryProtocolError,
     }),
 }));


### PR DESCRIPTION
## Summary
- extract a reusable browser host around `react-native-webview` with typed navigation state, structured bridge messaging, and JS evaluation
- add browser chrome, expanded browser state, and frame-aware instrumentation surfaced in the debug UI
- add a local iframe fixture to validate bridge lifecycle, frame metadata, and eval or script error reporting

## Validation
- npm run typecheck
- npm run lint
- npm run doctor
- npm run ci:ios-smoke
- npm run ios -- --device "iPhone 16"
- EXPO_PUBLIC_DEFAULT_URL=fixture://bridge npm run ios -- --device "iPhone 16"

Closes #2